### PR TITLE
Add a small description and a minimal example to the Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # servant-lucid - Blaze-html support for servant
 
 ![servant](https://raw.githubusercontent.com/haskell-servant/servant/master/servant.png)
+
+This package allows you to use [blaze-html](http://hackage.haskell.org/package/blaze-html-0.8.0.0/docs/Text-Blaze-Html5.html) to serve html pages in your servant APIs. More specifically, it exports a `HTML` datatype with the correct `MimeRender` instances so that you can write `type myAPI = Get '[HTML] a`.
+
+## Minimal example:
+
+```haskell
+{-# LANGUAGE OverloadedStrings, DataKinds #-}
+
+module Test where
+
+import           Servant
+import           Servant.HTML.Blaze
+import qualified Text.Blaze.Html5   as H
+
+type API = Get '[HTML] Homepage
+type Homepage = H.Html
+
+server :: Server API
+server = return myHome
+
+myHome :: Homepage
+myHome = H.docTypeHtml $ do
+    H.head $ do
+             H.title "Live to serve"
+    H.body $ do
+             H.h1 "Templates!"
+             H.p "This will be type-checked, rendered and served"
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![servant](https://raw.githubusercontent.com/haskell-servant/servant/master/servant.png)
 
-This package allows you to use [blaze-html](http://hackage.haskell.org/package/blaze-html-0.8.0.0/docs/Text-Blaze-Html5.html) to serve html pages in your servant APIs. More specifically, it exports a `HTML` datatype with the correct `MimeRender` instances so that you can write `type myAPI = Get '[HTML] a`.
+This package allows you to use [blaze-html](http://hackage.haskell.org/package/blaze-html-0.8.0.0/docs/Text-Blaze-Html5.html) to serve html pages in your servant APIs. More specifically, it exports a `HTML` datatype with the correct `MimeRender` instances so that you can write `type API = Get '[HTML] User` for example.
 
 ## Minimal example:
 


### PR DESCRIPTION
Nothing that can't be derived from reading the code here or the documentation of Blaze, but it's more beginner friendly imho like that -- I'd never used blaze and was a bit weirded out by the lack of any description at all.