### PR TITLE
Allow warp-3.4

### DIFF
--- a/servant-blaze.cabal
+++ b/servant-blaze.cabal
@@ -53,5 +53,5 @@ test-suite example
     , servant-blaze
     , servant-server >=0.4.4.5  && <0.21
     , wai            >=3.0.3.0  && <3.3
-    , warp           >=3.0.13.1 && <3.4
+    , warp           >=3.0.13.1 && <3.5
   default-language: Haskell2010


### PR DESCRIPTION
Tested using

    cabal test --enable-tests -c 'warp>=3.4' -w ghc-9.8.2
